### PR TITLE
test: isolate dspy patches

### DIFF
--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -80,7 +80,11 @@ async def test_end_to_end_single_call(lead_agent):
     with patch.object(lead_agent.planner, 'acall', new=AsyncMock(return_value=mock_plan)):
         with patch.object(lead_agent, 'execute_subagent_task', new=AsyncMock(return_value=mock_result)):
             with patch.object(lead_agent.synthesizer, 'acall', new=AsyncMock(return_value=mock_synthesis)):
-                with patch.object(lead_agent, 'generate_final_report', new=AsyncMock(return_value="# Report\nParis")):
+                async def fake_final_report(query: str, final_synthesis: str) -> str:
+                    path = f"cycle_{lead_agent.cycle_idx:03d}/final_report.md"
+                    lead_agent.fs.write(path, "# Report\nParis")
+                    return "# Report\nParis"
+                with patch.object(lead_agent, 'generate_final_report', new=fake_final_report):
                     result = await lead_agent.aforward(query)
 
     # Assertions: decision surface


### PR DESCRIPTION
## Summary
- avoid global modification of `dspy.ChainOfThought` by patching within each evaluation test
- stub final report generation to write expected file during workflow tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd3573cb14832791fd258894ee24dd