### PR TITLE
Ensure subagent results reuse task names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ Non‑goals: Human quickstarts, vendor‑specific recipes, or low‑level API do
 
 ## Testing & CI
 - Unit tests per tool (with fakes) and an end‑to‑end async flow test.
-- keep the tests as minimal and clean as possbile.
-- no need to test every single trival details in the code.
+- Keep tests minimal and clean.
+- No need to test every trivial detail.
 - All network usage mocked; tests deterministic and parallel‑friendly.
 - Use `uv` for env and test runs.
 
@@ -53,7 +53,7 @@ Non‑goals: Human quickstarts, vendor‑specific recipes, or low‑level API do
 - Enforce ceilings: tokens, runtime, parallelism; fail safe and explain why.
 
 ## Repository Pointers (for orientation, not coupling)
-- Current mapping: `agent.py` (orchestrates), `tools.py` (tool impls), `models.py` (data/signatures), `config.py` (settings), `tests/` (pytest), `memory/` (artifacts from running the agent).
+- Current mapping: `workflow.py` (orchestrates), `agent.py` (lightweight DSPy wrapper), `tools.py` (tool impls), `models.py` (data/signatures), `config.py` (settings), `tests/` (pytest), `memory/` (artifacts).
 - Treat these as reference anchors; the conceptual contracts above remain stable even if files change.
 
 ## PR Checklist (lightweight)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ A minimal multi-agent research system built with DSPy and OpenRouter, designed t
 
 ## Architecture
 
-This system implements a lead-subagent research pattern where:
-- **Lead Agent**: Plans research tasks, manages memory, and synthesizes results
-- **Subagents**: Execute specific research micro-tasks in parallel
-- **Memory Store**: Maintains research artifacts with lightweight summaries
+This system implements a lead–subagent pattern:
+- **Lead Agent** (`workflow.py`): Plans tasks, launches subagents, and synthesizes results
+- **Subagents**: Execute research micro-tasks in parallel
+- **Memory Store**: Filesystem that keeps artifacts with lightweight summaries
 
 ## Features
 
@@ -16,6 +16,7 @@ This system implements a lead-subagent research pattern where:
 - 🔍 Web search integration
 - 📊 Iterative refinement based on synthesis decisions
 - 🎯 Task-specific tool guidance and budgets
+- 📝 Todo list tool for tracking pending work
 
 ## BrowseComp Evaluation
 
@@ -56,7 +57,7 @@ OPENAI_API_KEY=your_key
 ## Usage
 
 ```bash
-uv run python -c "from agent import LeadAgent; import asyncio; agent = LeadAgent(); print(asyncio.run(agent.run('Your research question here')))"
+uv run python -c "from workflow import LeadAgent; import asyncio; agent = LeadAgent(); print(asyncio.run(agent.aforward('Your research question here')))"
 ```
 
 ## Testing

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -58,8 +58,7 @@ def test_browsecomp_metric():
                     reasoning="stubbed",
                     is_correct=is_correct,
                 )
-
-        with patch.object(_dspy, 'ChainOfThought', lambda *a, **k: _FakeJudge()):
+        with patch.object(_dspy, 'ChainOfThought', new=lambda *a, **k: _FakeJudge()):
             example = dspy.Example(problem="What is 2+2?", answer="4")
             assert 0.0 <= browsecomp_metric(example, dspy.Prediction(report="The answer is 4.")) <= 1.0
             assert 0.0 <= browsecomp_metric(example, dspy.Prediction(report="The answer is 5.")) <= 1.0
@@ -81,8 +80,7 @@ def test_browsecomp_evaluation_framework():
                     reasoning="stubbed",
                     is_correct=is_correct,
                 )
-
-        with patch.object(_dspy, 'ChainOfThought', lambda *a, **k: _FakeJudge()):
+        with patch.object(_dspy, 'ChainOfThought', new=lambda *a, **k: _FakeJudge()):
             class FakeAgent:
                 async def run(self, problem: str) -> str:
                     if "2+2" in problem:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -80,11 +80,11 @@ async def test_end_to_end_single_call(lead_agent):
     with patch.object(lead_agent.planner, 'acall', new=AsyncMock(return_value=mock_plan)):
         with patch.object(lead_agent, 'execute_subagent_task', new=AsyncMock(return_value=mock_result)):
             with patch.object(lead_agent.synthesizer, 'acall', new=AsyncMock(return_value=mock_synthesis)):
-                with patch.object(
-                    lead_agent.final_reporter,
-                    'acall',
-                    new=AsyncMock(return_value=types.SimpleNamespace(report="# Report\nParis")),
-                ):
+                async def fake_final_report(query: str, final_synthesis: str) -> str:
+                    path = f"cycle_{lead_agent.cycle_idx:03d}/final_report.md"
+                    lead_agent.fs.write(path, "# Report\nParis")
+                    return "# Report\nParis"
+                with patch.object(lead_agent, 'generate_final_report', new=fake_final_report):
                     result = await lead_agent.aforward(query)
 
     # Assertions: decision surface


### PR DESCRIPTION
## Summary
- merge latest main and resolve test conflicts
- align evaluation and workflow tests with new interfaces
- sync docs with main

## Testing
- `uv run pytest tests/test_eval.py -q`
- `uv run pytest tests/test_utils_markdown.py -q`
- `uv run pytest tests/test_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be49b1392083278fb991bab4fc967c