### PR TITLE
feat: enrich async logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,20 @@ Non‑goals: Human quickstarts, vendor‑specific recipes, or low‑level API do
 ## Instrumentation
 - Emit structured events: planning_started, tool_called, synthesis_started, verification_failed, artifact_written.
 - Log JSONL/structured lines safe for CI; redact secrets.
+- For debugging, decorate async functions with `utils.log_call`; set
+  `LOG_LEVEL=DEBUG` or call `configure_logging("DEBUG")` to emit inputs and
+  JSON-serialized results. Pass `return_attr="path.to.attr"` to log a nested
+  field from the returned object.
+
+```python
+from logging_config import configure_logging
+from utils import log_call
+
+@log_call(return_attr="prediction.text")
+async def plan(...): ...
+
+configure_logging("DEBUG")
+```
 
 ## Testing & CI
 - Unit tests per tool (with fakes) and an end‑to‑end async flow test.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ OPENAI_API_KEY=your_key
 uv run python -c "from agent import LeadAgent; import asyncio; agent = LeadAgent(); print(asyncio.run(agent.run('Your research question here')))"
 ```
 
+## Logging
+
+Use `@log_call` to trace async functions without touching their logic. It logs
+arguments and a JSON snapshot of the return value at debug level. The optional
+`return_attr` dotted path logs a nested attribute instead of the whole object.
+
+```python
+from logging_config import configure_logging
+from utils import log_call
+import asyncio
+
+@log_call(return_attr="prediction.text")
+async def plan(query: str): ...
+
+configure_logging("DEBUG")
+asyncio.run(plan("What is the capital of France?"))
+```
+
 ## Testing
 
 ```bash

--- a/workflow.py
+++ b/workflow.py
@@ -304,6 +304,7 @@ class LeadAgent(dspy.Module):
             elif next_action == "final_report":
                 # Generate and store final report
                 final_report = await self.generate_final_report(query, artifacts["decision"].synthesis)
+                self.fs.write(f"cycle_{self.cycle_idx:03d}/final_report.md", final_report)
                 artifacts["final_report"] = final_report
                 return {
                     "is_done": True,


### PR DESCRIPTION
## Summary
- document `log_call` usage with optional `return_attr` for nested value logging
- restore workflow test to original state and persist final report after generation
- clarify instrumentation guidelines in AGENTS and README

## Testing
- `uv run pytest tests/test_eval.py tests/test_utils_markdown.py -q`
- `uv run pytest tests/test_workflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd43ace6348327aea35e884d6baf56