### PR TITLE
refactor: code cleanup and configuration improvements

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -147,11 +147,14 @@ def parse_args():
     parser = create_model_cli_parser(
         "Run the single-loop research agent.",
         query=(
-            "Lamine vs Doue? Be objective and keep it research short and concise DO NOT ASK ANYTHING ELSE. Try to use tools provided to you to test our system first. Yet there will be no memory artifacts as this is the first session.",
-            "Query to run through the agent.",
+            None,  # Required - no default
+            "Research query to run through the agent.",
         ),
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.query is None:
+        parser.error("--query is required")
+    return args
 
 
 def main() -> None:

--- a/config.py
+++ b/config.py
@@ -14,11 +14,9 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 # ========== API KEYS ==========
-BRAVE_SEARCH_API_KEY = os.getenv("BRAVE_SEARCH_API_KEY")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
 OPENROUTER_BASE_URL = os.getenv("OPENROUTER_BASE_URL")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-EXA_API_KEY = os.getenv("EXA_API_KEY")
 PERPLEXITY_API_KEY = os.getenv("PERPLEXITY_API_KEY")
 
 # ========== MODEL CONFIGURATION ==========
@@ -135,9 +133,26 @@ BIG_MODEL_MAX_TOKENS = _DEFAULT_PRESET.big_max_tokens
 SMALL_MODEL_MAX_TOKENS = _DEFAULT_PRESET.small_max_tokens
 
 # ========== MODEL PARAMETERS ==========
-TEMPERATURE = 1.0
+TEMPERATURE = 1.0  # High temp for diverse research exploration
 # Max token limits are derived from the selected preset above.
 # Do not override them here; models like OpenRouter free tiers enforce 8–16k.
+
+# ========== TOOL DEFAULTS ==========
+# WebSearch defaults
+WEBSEARCH_MAX_RESULTS = 5  # Results per query
+WEBSEARCH_MAX_TOKENS_PER_PAGE = 1024  # Content truncation limit
+
+# Parallel execution
+PARALLEL_THREADS = 4  # Max concurrent tool invocations
+
+# Filesystem tree display
+FILESYSTEM_TREE_MAX_DEPTH = 3
+
+# Workspace isolation
+WORKSPACE_UUID_LENGTH = 8  # Characters from UUID for directory naming
+
+# Cleanup watchdog
+CLEANUP_WATCHDOG_TIMEOUT_SECONDS = 30  # Force exit if DSPy/LiteLLM cleanup hangs
 
 # ========== EVALUATION MODELS (Fixed for experimental consistency) ==========
 # These models are used for evaluation/optimization across all experiments

--- a/dataset.py
+++ b/dataset.py
@@ -87,7 +87,7 @@ class BrowseCompDataset:
             examples.append(example)
         
         # Sample if requested
-        if self.num_examples:
+        if self.num_examples is not None and self.num_examples > 0:
             random.seed(self.seed)
             examples = random.sample(examples, min(self.num_examples, len(examples)))
             

--- a/eval.py
+++ b/eval.py
@@ -98,7 +98,8 @@ class BrowseCompEvaluator:
     
     def __init__(self, args):
         self.args = args
-        
+        self.reflection_lm = None  # Initialized lazily if optimization requested
+
         # Initialize grader LM once for all evaluations (major efficiency improvement)
         self.grader_lm = dspy.LM(
             model=GRADER_MODEL,
@@ -107,7 +108,7 @@ class BrowseCompEvaluator:
             **lm_kwargs_for(GRADER_MODEL),
         )
         self.judge = dspy.ChainOfThought(BrowseCompJudge)
-        
+
         # Initialize reflection LM for GEPA optimization if needed
         if args.optimize:
             self.reflection_lm = dspy.LM(

--- a/utils.py
+++ b/utils.py
@@ -9,7 +9,11 @@ import uuid
 from pathlib import Path
 from typing import Any, Iterable, Tuple
 
-from config import MODEL_PRESETS
+from config import (
+    MODEL_PRESETS,
+    WORKSPACE_UUID_LENGTH,
+    CLEANUP_WATCHDOG_TIMEOUT_SECONDS,
+)
 
 
 def create_model_cli_parser(
@@ -42,7 +46,7 @@ def iter_model_presets() -> Iterable[tuple[str, Any]]:
 
 def create_isolated_workspace(base_dir: str = "memory_eval") -> Path:
     """Create unique workspace directory for parallel-safe operations."""
-    work_dir = Path(base_dir) / str(uuid.uuid4())[:8]
+    work_dir = Path(base_dir) / str(uuid.uuid4())[:WORKSPACE_UUID_LENGTH]
     work_dir.mkdir(parents=True, exist_ok=True)
     return work_dir
 
@@ -55,7 +59,7 @@ def cleanup_workspace(work_dir: Path) -> None:
         pass
 
 
-def start_cleanup_watchdog(grace_period_seconds: int = 30) -> None:
+def start_cleanup_watchdog(grace_period_seconds: int = CLEANUP_WATCHDOG_TIMEOUT_SECONDS) -> None:
     """Force exit if cleanup hangs (workaround for DSPy/LiteLLM bug)."""
     def force_exit():
         time.sleep(grace_period_seconds)


### PR DESCRIPTION
## Summary

Cleaned up code smells and standardized configuration across the multi-agent research system. Removed dead code, extracted magic numbers to config constants, and fixed several code quality issues.

## Changes

- **Delete dead code**: Removed unused API key variables (`BRAVE_SEARCH_API_KEY`, `EXA_API_KEY`)
- **Extract magic numbers**: Moved hardcoded values to `config.py` constants with documentation
- **Remove test artifacts**: Made `--query` CLI argument required instead of hardcoded test query
- **Import cleanup**: Moved `shutil` to top of `tools.py`
- **Boolean blindness fix**: Explicit `None` check in `dataset.py`
- **Temporal coupling fix**: Explicit `reflection_lm = None` initialization in `eval.py`

## Testing

All tests pass (18 passed, 3 skipped). No breaking changes.

## Related Issues

See issues #22-26 for discussion on larger refactors (error handling standardization, Path consistency, ModelPreset usage).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes web search, parallelism, filesystem, and cleanup defaults in config; enforces required --query; updates tools/utils to use these constants; fixes dataset sampling guard and initializes eval optimizer lazily.
> 
> - **CLI/Agent**:
>   - Require `--query` (no default) with explicit validation in `agent.py`.
> - **Config**:
>   - Remove unused API keys (`BRAVE_SEARCH_API_KEY`, `EXA_API_KEY`).
>   - Add centralized defaults: `WEBSEARCH_MAX_RESULTS`, `WEBSEARCH_MAX_TOKENS_PER_PAGE`, `PARALLEL_THREADS`, `FILESYSTEM_TREE_MAX_DEPTH`, `WORKSPACE_UUID_LENGTH`, `CLEANUP_WATCHDOG_TIMEOUT_SECONDS`.
>   - Clarify `TEMPERATURE` comment.
> - **Tools**:
>   - `WebSearchTool` uses config-driven `max_results`/`max_tokens_per_page`.
>   - `ParallelToolCall` defaults `num_threads` to `PARALLEL_THREADS`.
>   - `FileSystemTool.tree` defaults to `FILESYSTEM_TREE_MAX_DEPTH`; import `shutil` moved top-level.
> - **Utils**:
>   - `create_isolated_workspace` and `start_cleanup_watchdog` parameterized by config (`WORKSPACE_UUID_LENGTH`, `CLEANUP_WATCHDOG_TIMEOUT_SECONDS`).
> - **Dataset/Eval**:
>   - Fix sampling condition with explicit `None` check in `dataset.py`.
>   - Initialize `reflection_lm = None` lazily in `eval.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2940926f8c8b028a075781c89f9a1b6e34549064. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->