### PR TITLE
refactor(config): simplify model config with lead/sub naming

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,9 @@
 """
 Configuration module for multi-agent research system.
 Loads environment variables and exposes model settings.
-Logging configuration is handled in logging_config.py to avoid side effects.
 """
 
 import os
-from dataclasses import dataclass
-from typing import Final
 
 from dotenv import load_dotenv
 
@@ -21,93 +18,29 @@ PERPLEXITY_API_KEY = os.getenv("PERPLEXITY_API_KEY")
 
 # ========== MODEL CONFIGURATION ==========
 
-@dataclass(frozen=True)
-class ModelPreset:
-    big: str
-    small: str
-    big_max_tokens: int
-    small_max_tokens: int
+# Default models (placeholder - will revisit after analyzing feature/metric-eval branch)
+DEFAULT_LEAD_MODEL = "openai/gpt-5-mini"
+DEFAULT_SUB_MODEL = "openai/gpt-5-mini"
+DEFAULT_LEAD_MAX_TOKENS = 30000
+DEFAULT_SUB_MAX_TOKENS = 30000
+DEFAULT_TEMPERATURE = 1.0
 
 
-MODEL_PRESETS: Final[dict[str, ModelPreset]] = {
-    "gpt-5-mini": ModelPreset(
-        big="openai/gpt-5-mini",
-        small="openai/gpt-5-mini",
-        big_max_tokens=30000,
-        small_max_tokens=30000,
-    ),
-    "kimi-k2": ModelPreset(
-        big="openrouter/moonshotai/kimi-k2:free",
-        small="openrouter/moonshotai/kimi-k2:free",
-        big_max_tokens=30000,
-        small_max_tokens=30000,
-    ),
-    "qwen3-coder": ModelPreset(
-        big="openrouter/qwen/qwen3-coder:free",
-        small="openrouter/qwen/qwen3-coder:free",
-        big_max_tokens=12000,
-        small_max_tokens=12000,
-    ),
-    "gpt-oss-120b": ModelPreset(
-        big="openrouter/openai/gpt-oss-120b:free",
-        small="openrouter/openai/gpt-oss-120b:free",
-        big_max_tokens=30000,
-        small_max_tokens=30000,
-    ),
-    "deepseek-v3.1": ModelPreset(
-        big="openrouter/deepseek/deepseek-chat-v3.1:free",
-        small="openrouter/deepseek/deepseek-chat-v3.1:free",
-        big_max_tokens=30000,
-        small_max_tokens=30000,
-    ),
-}
-
-DEFAULT_MODEL_PRESET: Final[str] = "gpt-5-mini"
-
-def _resolve_override(
-    override: str | None,
-    *,
-    slot: str,
-    fallback: ModelPreset,
-) -> tuple[str, int]:
-    """Resolve model id and token cap for a slot using preset aliases."""
-
-    fallback_tokens = getattr(fallback, f"{slot}_max_tokens")
-
-    if not override:
-        return getattr(fallback, slot), fallback_tokens
-
-    candidate = override.lower()
-    if candidate in MODEL_PRESETS:
-        preset = MODEL_PRESETS[candidate]
-        tokens = getattr(preset, f"{slot}_max_tokens")
-        return getattr(preset, slot), tokens
-
-    # Accept fully qualified model identifiers while defaulting to the preset token cap.
-    return override, fallback_tokens
-
-
-def resolve_model_config(
-    preset: str | None = None,
-    big_override: str | None = None,
-    small_override: str | None = None,
-) -> ModelPreset:
-    resolved_name = (preset or DEFAULT_MODEL_PRESET).lower()
-    if resolved_name not in MODEL_PRESETS:
-        valid = ", ".join(sorted(MODEL_PRESETS))
-        raise ValueError(f"Unknown model preset '{resolved_name}'. Valid options: {valid}.")
-
-    preset_config = MODEL_PRESETS[resolved_name]
-
-    big_id, big_tokens = _resolve_override(big_override, slot="big", fallback=preset_config)
-    small_id, small_tokens = _resolve_override(small_override, slot="small", fallback=preset_config)
-
-    return ModelPreset(
-        big=big_id,
-        small=small_id,
-        big_max_tokens=big_tokens,
-        small_max_tokens=small_tokens,
-    )
+class ModelConfig:
+    """Model configuration bundle for lead agent and subagents."""
+    def __init__(
+        self,
+        lead: str = DEFAULT_LEAD_MODEL,
+        sub: str = DEFAULT_SUB_MODEL,
+        lead_max_tokens: int = DEFAULT_LEAD_MAX_TOKENS,
+        sub_max_tokens: int = DEFAULT_SUB_MAX_TOKENS,
+        temperature: float = DEFAULT_TEMPERATURE,
+    ):
+        self.lead = lead
+        self.sub = sub
+        self.lead_max_tokens = lead_max_tokens
+        self.sub_max_tokens = sub_max_tokens
+        self.temperature = temperature
 
 
 def lm_kwargs_for(model_id: str) -> dict[str, str]:
@@ -125,17 +58,6 @@ def lm_kwargs_for(model_id: str) -> dict[str, str]:
 
     return {"api_key": OPENAI_API_KEY}
 
-
-_DEFAULT_PRESET = resolve_model_config()
-BIG_MODEL = _DEFAULT_PRESET.big
-SMALL_MODEL = _DEFAULT_PRESET.small
-BIG_MODEL_MAX_TOKENS = _DEFAULT_PRESET.big_max_tokens
-SMALL_MODEL_MAX_TOKENS = _DEFAULT_PRESET.small_max_tokens
-
-# ========== MODEL PARAMETERS ==========
-TEMPERATURE = 1.0  # High temp for diverse research exploration
-# Max token limits are derived from the selected preset above.
-# Do not override them here; models like OpenRouter free tiers enforce 8–16k.
 
 # ========== TOOL DEFAULTS ==========
 # WebSearch defaults
@@ -157,11 +79,11 @@ CLEANUP_WATCHDOG_TIMEOUT_SECONDS = 30  # Force exit if DSPy/LiteLLM cleanup hang
 # ========== EVALUATION MODELS (Fixed for experimental consistency) ==========
 # These models are used for evaluation/optimization across all experiments
 # to eliminate judge/optimizer variance as a confounding variable.
-GRADER_MODEL: Final[str] = "openai/gpt-5"  # Judges answer correctness
-GRADER_MAX_TOKENS: Final[int] = 16000  # Large budget for reasoning chains
+GRADER_MODEL = "openai/gpt-5"  # Judges answer correctness
+GRADER_MAX_TOKENS = 16000  # Large budget for reasoning chains
 
-OPTIMIZER_MODEL: Final[str] = "openai/gpt-5"  # GEPA prompt optimization
-OPTIMIZER_MAX_TOKENS: Final[int] = 32000  # Large budget for prompt refinement
+OPTIMIZER_MODEL = "openai/gpt-5"  # GEPA prompt optimization
+OPTIMIZER_MAX_TOKENS = 32000  # Large budget for prompt refinement
 
 # ========== COST CONFIGURATION ==========
 
@@ -170,7 +92,7 @@ WEBSEARCH_COST_PER_CALL_USD = float(os.getenv("WEBSEARCH_COST_PER_CALL_USD", "0.
 # Model pricing per 1 MILLION tokens (industry standard format)
 # Matches OpenAI/Anthropic/Google pricing display conventions
 # Note: Even when using free tier, we track AS IF paying for meaningful cost comparisons
-LM_PRICING: Final[dict[str, dict[str, float]]] = {
+LM_PRICING = {
     # OpenAI GPT-5 Models (Standard Tier - verified 2025)
     "openai/gpt-5-mini": {
         "input": 0.25,           # $0.25 per 1M tokens

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-"""Tests for config resolve_model_config overrides."""
+"""Tests for config ModelConfig."""
 
 from pathlib import Path
 import sys
@@ -7,20 +7,26 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from config import resolve_model_config, MODEL_PRESETS
+from config import (
+    ModelConfig,
+    DEFAULT_LEAD_MODEL,
+    DEFAULT_SUB_MODEL,
+    DEFAULT_LEAD_MAX_TOKENS,
+    DEFAULT_SUB_MAX_TOKENS,
+    DEFAULT_TEMPERATURE,
+)
 
 
-def test_override_accepts_preset_alias_for_big_model():
-    base = resolve_model_config(preset="gpt-5-mini", big_override="kimi-k2")
-    assert base.big == MODEL_PRESETS["kimi-k2"].big
+def test_model_config_uses_defaults():
+    config = ModelConfig()
+    assert config.lead == DEFAULT_LEAD_MODEL
+    assert config.sub == DEFAULT_SUB_MODEL
+    assert config.lead_max_tokens == DEFAULT_LEAD_MAX_TOKENS
+    assert config.sub_max_tokens == DEFAULT_SUB_MAX_TOKENS
+    assert config.temperature == DEFAULT_TEMPERATURE
 
 
-def test_override_accepts_preset_alias_for_small_model():
-    base = resolve_model_config(preset="gpt-5-mini", small_override="qwen3-coder")
-    assert base.small == MODEL_PRESETS["qwen3-coder"].small
-
-
-def test_override_passes_through_full_identifier():
-    custom_small = "openrouter/openai/gpt-5-mini:free"
-    base = resolve_model_config(preset="gpt-5-mini", small_override=custom_small)
-    assert base.small == custom_small
+def test_model_config_accepts_custom_models():
+    config = ModelConfig(lead="custom/lead", sub="custom/sub")
+    assert config.lead == "custom/lead"
+    assert config.sub == "custom/sub"

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -67,7 +67,8 @@ def test_browsecomp_program_wrapper():
             async def run(self, problem: str) -> str:
                 return f"Report for: {problem}"
 
-        program = BrowseCompProgram(FakeAgent())
+        program = BrowseCompProgram()  # Uses default preset
+        program.agent = FakeAgent()    # Replace with mock for testing
         assert hasattr(program, 'forward') and callable(program.forward)
 
 
@@ -116,7 +117,8 @@ def test_browsecomp_evaluation_framework():
                 return f"Report for: {problem}"
 
         with patch.object(_dspy, 'ChainOfThought', new=lambda *a, **k: _FakeJudge()):
-            program = BrowseCompProgram(FakeAgent())
+            program = BrowseCompProgram()  # Uses default preset
+            program.agent = FakeAgent()    # Replace with mock for testing
             dataset = [dspy.Example(problem="What is 2+2?", answer="4")]
             
             # Test the evaluation framework (minimal)

--- a/utils.py
+++ b/utils.py
@@ -7,10 +7,11 @@ import threading
 import time
 import uuid
 from pathlib import Path
-from typing import Any, Iterable, Tuple
+from typing import Tuple
 
 from config import (
-    MODEL_PRESETS,
+    DEFAULT_LEAD_MODEL,
+    DEFAULT_SUB_MODEL,
     WORKSPACE_UUID_LENGTH,
     CLEANUP_WATCHDOG_TIMEOUT_SECONDS,
 )
@@ -19,29 +20,16 @@ from config import (
 def create_model_cli_parser(
     description: str,
     *,
-    include_list: bool = False,
     query: Tuple[str, str] | None = None,
 ) -> argparse.ArgumentParser:
     """Return an ArgumentParser with shared model arguments."""
     parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        "--model",
-        choices=sorted(MODEL_PRESETS.keys()),
-        help="Model preset to use for both big and small slots.",
-    )
-    parser.add_argument("--model-big", dest="model_big", help="Override the big model identifier.")
-    parser.add_argument("--model-small", dest="model_small", help="Override the small model identifier.")
-    if include_list:
-        parser.add_argument("--list-models", action="store_true", help="List available model presets and exit.")
+    parser.add_argument("--lead", default=DEFAULT_LEAD_MODEL, help="Lead agent model.")
+    parser.add_argument("--sub", default=DEFAULT_SUB_MODEL, help="Subagent model.")
     if query is not None:
         default, help_text = query
         parser.add_argument("--query", default=default, help=help_text)
     return parser
-
-
-def iter_model_presets() -> Iterable[tuple[str, Any]]:
-    """Yield model presets sorted by key."""
-    return sorted(MODEL_PRESETS.items())
 
 
 def create_isolated_workspace(base_dir: str = "memory_eval") -> Path:


### PR DESCRIPTION
- Remove preset system (MODEL_PRESETS, resolve_model_config, _resolve_override)
- Rename ModelPreset to ModelConfig with lead/sub instead of big/small
- Simplify CLI to --lead and --sub flags with sensible defaults
- Update agent.py, eval.py, utils.py to use new naming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces preset-based big/small model selection with a `ModelConfig` using lead/sub models and updates agent, eval, utils, and tests; CLI now uses `--lead`/`--sub`.
> 
> - **Config**:
>   - Introduce `ModelConfig` with `lead`, `sub`, token caps, and `temperature`.
>   - Remove preset system (`MODEL_PRESETS`, `resolve_model_config`, overrides) and related constants.
>   - Add defaults (`DEFAULT_LEAD_MODEL`, `DEFAULT_SUB_MODEL`, etc.) and keep evaluator constants/pricing in `LM_PRICING`.
>   - `lm_kwargs_for` unchanged in behavior; keys validated per provider.
> - **CLI/Utils**:
>   - Replace preset flags with `--lead` and `--sub` in `create_model_cli_parser`.
>   - Remove preset listing/iteration helpers.
>   - Keep workspace helpers; add cleanup watchdog utility.
> - **Agent (`agent.py`)**:
>   - Accept `config: ModelConfig`; construct lead/sub LMs from it.
>   - Simplify init and logging; use shared `ChatAdapter`.
>   - CLI path updated to build `ModelConfig` from `--lead`/`--sub`.
> - **Evaluation (`eval.py`)**:
>   - `BrowseCompProgram` accepts `ModelConfig`; agent instantiated with it.
>   - DSPy configuration uses lead model from `ModelConfig`.
>   - Streamline args (remove preset listing); print selected models.
>   - Evaluator initializes fixed grader/optimizer LMs and computes costs via `LM_PRICING`.
> - **Tests**:
>   - Replace preset/override tests with `ModelConfig` default/custom tests.
>   - Update eval tests to construct `BrowseCompProgram()` and inject fake agent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86af576e0cab2612048611913cca3ee78357fce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->