### PR TITLE
Refactor: Move LM_PRICING to eval.py (#45)

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,17 +50,4 @@ GRADER_MAX_TOKENS = 40000  # Large budget for reasoning chains
 OPTIMIZER_MODEL = "openrouter/openai/gpt-5.2"  # GEPA prompt optimization
 OPTIMIZER_MAX_TOKENS = 40000  # Large budget for prompt refinement
 
-# ========== COST CONFIGURATION ==========
 
-# Model pricing per 1M tokens (for cost tracking in eval.py)
-# Add your model here if using --lead/--sub with a custom model
-# Unknown models will log a warning and skip cost calculation
-LM_PRICING = {
-    "openrouter/x-ai/grok-4.1-fast": {"input": 0.20, "output": 0.50},
-    "openrouter/deepseek/deepseek-v3.2": {"input": 0.24, "output": 0.38},
-    "openrouter/google/gemini-3-flash-preview": {"input": 0.10, "output": 0.40},
-    "openrouter/google/gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40},
-    "openrouter/openai/gpt-oss-120b": {"input": 0.039, "output": 0.19},
-    "openrouter/qwen/qwen3-235b-a22b-2507": {"input": 0.071, "output": 0.463},
-    "openrouter/openai/gpt-5.2": {"input": 1.75, "output": 14.0, "cached_input": 0.175},
-}

--- a/eval.py
+++ b/eval.py
@@ -16,7 +16,6 @@ from agent import Agent
 from models import BrowseCompJudge, LLMJudgeAnswer
 from config import (
     ModelConfig,
-    LM_PRICING,
     GRADER_MODEL,
     GRADER_MAX_TOKENS,
     OPTIMIZER_MODEL,
@@ -31,6 +30,18 @@ from utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Model pricing per 1M tokens
+# Add your model here if using --lead/--sub with a custom model
+LM_PRICING = {
+    "openrouter/x-ai/grok-4.1-fast": {"input": 0.20, "output": 0.50},
+    "openrouter/deepseek/deepseek-v3.2": {"input": 0.24, "output": 0.38},
+    "openrouter/google/gemini-3-flash-preview": {"input": 0.10, "output": 0.40},
+    "openrouter/google/gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40},
+    "openrouter/openai/gpt-oss-120b": {"input": 0.039, "output": 0.19},
+    "openrouter/qwen/qwen3-235b-a22b-2507": {"input": 0.071, "output": 0.463},
+    "openrouter/openai/gpt-5.2": {"input": 1.75, "output": 14.0, "cached_input": 0.175},
+}
 
 class MultiAgentResearchSystem(dspy.Module):
     """


### PR DESCRIPTION
## Summary
Co-locates `LM_PRICING` with `calculate_lm_cost()` - the only place it's used.

## Context
Part of the cost tracking cleanup. DSPy already handles LM usage tracking via `prediction.get_lm_usage()`, so we just need pricing data where we calculate costs.

## Changes
- **config.py**: Remove `LM_PRICING` dict
- **eval.py**: Add `LM_PRICING` dict after imports

Closes #45